### PR TITLE
chore: Agora o CI é chamado ao ser publicado uma nova Release.

### DIFF
--- a/.github/workflows/CI Docker.yml
+++ b/.github/workflows/CI Docker.yml
@@ -1,8 +1,8 @@
 name: Publish Docker image
 
 on:
-  push:
-    branches: ["development"]
+  release:
+    types: [published]
 
 jobs:
   build-and-push-image:
@@ -26,6 +26,10 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Neste PR, agora o CI é acionado quando for publicado uma nova **Release** no repositório.